### PR TITLE
djatoka_region method should set the Djatoka::Region @rft_id property

### DIFF
--- a/lib/djatoka/iiif_request.rb
+++ b/lib/djatoka/iiif_request.rb
@@ -105,7 +105,7 @@ module Djatoka
         raise IiifException.new(msg)
       end
 
-      region = @resolver.region(@iiif_params[:id])
+      region = @resolver.region(@id)
 
       if(@iiif_params[:region] =~ /^(\d+),(\d+),(\d+),(\d+)$/)
         region.region("#{$2},#{$1},#{$4},#{$3}")

--- a/test/test_iiif_request.rb
+++ b/test/test_iiif_request.rb
@@ -11,6 +11,10 @@ class TestDjatokaIiifRequest < Test::Unit::TestCase
         setup do
           @region = @req.region('full').size('full').rotation('0').quality('native').format('jpg').djatoka_region
         end
+	
+	should 'set id properly' do
+	  assert_equal @identifier, @region.rft_id
+	end
 
         should 'set region to nil from full' do
           assert_nil @region.query.region


### PR DESCRIPTION
This commit fixes a problem with Djatoka::IiifRequest#djatoka_region in which the identifier of the image is not set correctly. (There is no :id symbol in the @iiif_params hash of the Djatoka::IiifRequest object -- the image id is actually in the @id attribute of the Djatoka::IiifRequest object.)
